### PR TITLE
Fix otp caching unwanted requests results

### DIFF
--- a/test/wrappers/otp_test.rb
+++ b/test/wrappers/otp_test.rb
@@ -29,8 +29,13 @@ class Wrappers::OtpTest < Minitest::Test
 
   def test_router_no_route
     otp = RouterWrapper::OTP_BORDEAUX
-    result = otp.route([[-18.90928, 47.53381], [-16.92609, 145.75843]], :time, nil, nil, 'en', true)
-    assert 0 == result[:features].size
+    otp.cache = CacheManager.new(ActiveSupport::Cache::FileStore.new(File.join(Dir.tmpdir, 'router'), namespace: 'router', expires_in: 60*60*24*1))
+    locs = [[-18.90928, 47.53381], [-16.92609, 145.75843]]
+    result = otp.route(locs, :time, nil, nil, 'en', true)
+    key = [:otp, :route, 'bordeaux', Digest::MD5.hexdigest(Marshal.dump([otp.url, locs[0], locs[-1], :time, otp.send(:monday_morning), false, 'en', {}]))]
+
+    assert_nil otp.cache.read(key)
+    assert_equal 0, result[:features].size
   end
 
   def test_router_with_max_walk_distance


### PR DESCRIPTION
In fact, when the OTP service returns a result without a route due to a lack of data, the result is cached, i.e. even when the data is updated, it returns an empty result.