### PR TITLE
Fix HERE when asking for route without mortorways or tolls

### DIFF
--- a/test/wrappers/here_test.rb
+++ b/test/wrappers/here_test.rb
@@ -162,16 +162,24 @@ class Wrappers::HereTest < Minitest::Test
 
   def test_distance_should_define_row_number
     [
-      { distance: 100, max_srcs: 15 },
-      { distance: 1_000, max_srcs: 15 },
-      { distance: 1_500, max_srcs: 10 },
-      { distance: 1_700, max_srcs: 8 },
-      { distance: 1_800, max_srcs: 7 },
-      { distance: 1_900, max_srcs: 6 },
-      { distance: 2_000, max_srcs: 5 },
-      { distance: 3_000, max_srcs: 1 }
+      { distance: 100, max_srcs: 15, options: {} },
+      { distance: 100, max_srcs: 15, options: { motorway: false } },
+      { distance: 1_000, max_srcs: 15, options: {} },
+      { distance: 1_000, max_srcs: 6, options: { motorway: false } },
+      { distance: 1_500, max_srcs: 10, options: {} },
+      { distance: 1_500, max_srcs: 5, options: { motorway: false } },
+      { distance: 1_700, max_srcs: 8, options: {} },
+      { distance: 1_700, max_srcs: 4, options: { motorway: false } },
+      { distance: 1_800, max_srcs: 7, options: {} },
+      { distance: 1_800, max_srcs: 4, options: { motorway: false } },
+      { distance: 1_900, max_srcs: 6, options: {} },
+      { distance: 1_900, max_srcs: 4, options: { motorway: false } },
+      { distance: 2_000, max_srcs: 5, options: {} },
+      { distance: 2_000, max_srcs: 3, options: { motorway: false } },
+      { distance: 3_000, max_srcs: 1, options: {} },
+      { distance: 3_000, max_srcs: 1, options: { motorway: false } }
     ].each do |obj|
-      assert_equal(RouterWrapper::HERE_TRUCK.send(:max_srcs, obj[:distance]), obj[:max_srcs])
+      assert_equal(obj[:max_srcs], RouterWrapper::HERE_TRUCK.send(:max_srcs, obj[:distance], obj[:options]))
     end
   end
 end

--- a/test/wrappers/here_test.rb
+++ b/test/wrappers/here_test.rb
@@ -162,24 +162,26 @@ class Wrappers::HereTest < Minitest::Test
 
   def test_distance_should_define_row_number
     [
-      { distance: 100, max_srcs: 15, options: {} },
-      { distance: 100, max_srcs: 15, options: { motorway: false } },
-      { distance: 1_000, max_srcs: 15, options: {} },
-      { distance: 1_000, max_srcs: 6, options: { motorway: false } },
-      { distance: 1_500, max_srcs: 10, options: {} },
-      { distance: 1_500, max_srcs: 5, options: { motorway: false } },
-      { distance: 1_700, max_srcs: 8, options: {} },
-      { distance: 1_700, max_srcs: 4, options: { motorway: false } },
-      { distance: 1_800, max_srcs: 7, options: {} },
-      { distance: 1_800, max_srcs: 4, options: { motorway: false } },
-      { distance: 1_900, max_srcs: 6, options: {} },
-      { distance: 1_900, max_srcs: 4, options: { motorway: false } },
-      { distance: 2_000, max_srcs: 5, options: {} },
-      { distance: 2_000, max_srcs: 3, options: { motorway: false } },
-      { distance: 3_000, max_srcs: 1, options: {} },
-      { distance: 3_000, max_srcs: 1, options: { motorway: false } }
+      { distance: 100, max_srcs: 15, max_dsts: 100 },
+      { distance: 100, max_srcs: 8, max_dsts: 100, options: { motorway: false } },
+      { distance: 500, max_srcs: 7, max_dsts: 100, options: { motorway: false } },
+      { distance: 1_000, max_srcs: 15, max_dsts: 100 },
+      { distance: 1_000, max_srcs: 6, max_dsts: 100, options: { motorway: false } },
+      { distance: 1_500, max_srcs: 10, max_dsts: 100 },
+      { distance: 1_500, max_srcs: 4, max_dsts: 50, options: { motorway: false } },
+      { distance: 1_700, max_srcs: 8, max_dsts: 100 },
+      { distance: 1_700, max_srcs: 3, max_dsts: 50, options: { motorway: false } },
+      { distance: 1_800, max_srcs: 7, max_dsts: 100 },
+      { distance: 1_800, max_srcs: 3, max_dsts: 50, options: { motorway: false } },
+      { distance: 1_900, max_srcs: 6, max_dsts: 100 },
+      { distance: 1_900, max_srcs: 3, max_dsts: 50, options: { motorway: false } },
+      { distance: 2_000, max_srcs: 5, max_dsts: 100 },
+      { distance: 2_000, max_srcs: 3, max_dsts: 50, options: { motorway: false } },
+      { distance: 3_000, max_srcs: 1, max_dsts: 100 },
+      { distance: 3_000, max_srcs: 1, max_dsts: 50, options: { motorway: false } }
     ].each do |obj|
       assert_equal(obj[:max_srcs], RouterWrapper::HERE_TRUCK.send(:max_srcs, obj[:distance], obj[:options]))
+      assert_equal(obj[:max_dsts], RouterWrapper::HERE_TRUCK.send(:max_dsts, obj[:distance], [*1..100], obj[:options]))
     end
   end
 end

--- a/wrappers/here.rb
+++ b/wrappers/here.rb
@@ -471,19 +471,19 @@ module Wrappers
 
     ##
     # motorway or toll -> dist_km < 1000km: 15, 1500km: 10, 2000km: 5
-    # !motorway or !toll -> dist_km < 1000km: 15, 1000km: 6, 2000km: 3, 3000km: 1
-    def max_srcs(dist_km, options)
-      if dist_km <= 1_000
+    # !motorway or !toll -> dist_km : < 500km: 8, 500km: 7, 1000km: 6, 2000km: 3, 3000km: 1
+    def max_srcs(dist_km, options = {})
+      if options && (options[:motorway] == false || options[:toll] == false)
+        [9 + (dist_km * -0.003).floor, 1].max
+      elsif dist_km <= 1_000
         15
-      elsif options[:motorway] == false || options[:toll] == false
-        [8 - (dist_km * 0.0025).floor, 1].max
       else
         [25 - (dist_km / 100).floor, 1].max
       end
     end
 
-    def max_dsts(dist_km, dsts, options)
-      if dist_km > 1000 && (options[:motorway] == false || options[:toll] == false)
+    def max_dsts(dist_km, dsts, options = {})
+      if dist_km > 1000 && options && (options[:motorway] == false || options[:toll] == false)
         [50, dsts.size].min
       else
         [100, dsts.size].min


### PR DESCRIPTION
While a 1 x 100 matrix ends in a timeout (> 1 min) when the diagonal is greater than 1000 km with the options *motorway* or *toll* to *false*, I noticed that making a 6 x 50 matrix can be done in 40 sec. That's why this PR proposes to divide the matrices according to these three parameters.

A request for a matrix 192x192 of 1000 km failing in timeout before, now ends successfully in 7 minutes.