### PR TITLE
HERE: Return more details on unreachable point

### DIFF
--- a/wrappers/here.rb
+++ b/wrappers/here.rb
@@ -327,7 +327,7 @@ module Wrappers
               elsif additional_data.include?({ 'key' => 'error_code', 'value' => 'NGEO_ERROR_ROUTING_CANCELLED' })
                 return
               elsif additional_data.include?({ 'key' => 'error_code', 'value' => 'NGEO_ERROR_ROUTE_NO_START_POINT' })
-                raise UnreachablePointError
+                raise UnreachablePointError.new(error), "Here, UnreachablePoint: #{params.keys.grep(/waypoint/).map{|key| params[key]}}"
               elsif error['subtype'] == 'InvalidInputData'
                 raise RouterWrapper::InvalidArgumentError.new(error), "Here, #{error['subtype']}: #{error['details']} (#{additional_data.first['key']} : #{additional_data.first['value']})"
               elsif error['subtype'] == 'NoRouteFound'


### PR DESCRIPTION
Actually when a point is unreachable, the router ends in error without giving any informations about the locations, this PR adds it.

Example: `Wrappers::UnreachablePointError (Here, UnreachablePoint: ["geo!0.0,0.0", "geo!0.0,0.0"])` and will render a 204 HTTP status like it uses to do.