### PR TITLE
Allow quotas to become unlimited

### DIFF
--- a/api/v01/api.rb
+++ b/api/v01/api.rb
@@ -92,7 +92,7 @@ module Api
 
             quota.slice(:daily, :monthly, :yearly).each do |k, v|
               count = redis_count.get(count_base_key(op, k)).to_i
-              raise QuotaExceeded.new("Too many #{k} requests", limit: v, remaining: v - count, reset: k) if count + request_size > v
+              raise QuotaExceeded.new("Too many #{k} requests", limit: v, remaining: v - count, reset: k) if v && count + request_size > v
             end
           end if raise_if_exceed
         end

--- a/api/v01/matrix.rb
+++ b/api/v01/matrix.rb
@@ -36,7 +36,7 @@ module Api
       default_format :json
 
       before do
-        params_limit = APIBase.profile(params[:api_key])[:params_limit].merge(RouterWrapper.access[params[:api_key]][:params_limit] || {})
+        params_limit = APIBase.profile(params[:api_key])[:params_limit]
         if !params_limit[:locations].nil?
           error!({message: "Exceeded \"matrix\" limit authorized for your account: #{params_limit[:locations]}. Please contact support or sales to increase limits."}, 413) if APIBase.count_matrix_locations(params) > params_limit[:locations]
         end

--- a/api/v01/route.rb
+++ b/api/v01/route.rb
@@ -37,7 +37,7 @@ module Api
       default_format :json
 
       before do
-        params_limit = APIBase.profile(params[:api_key])[:params_limit].merge(RouterWrapper.access[params[:api_key]][:params_limit] || {})
+        params_limit = APIBase.profile(params[:api_key])[:params_limit]
         if !params_limit[:locations].nil?
           error!({message: "Exceeded \"routes\" limit authorized for your account: #{params_limit[:locations]}. Please contact support or sales to increase limits."}, 413) if APIBase.count_route_locations(params) > params_limit[:locations]
         end

--- a/config/access.rb
+++ b/config/access.rb
@@ -26,6 +26,11 @@ module RouterWrapper
       { operation: :matrix, daily: 2 },
       { monthly: 4 }
     ]},
+    'demo_nil_quotas' => { profile: :standard, params_limit: { locations: 2 }, quotas: [
+      { operation: :route, daily: nil },
+      { operation: :isoline, daily: nil },
+      { operation: :matrix, daily: nil }
+    ]},
     'expired' => { profile: :standard, expire_at: '2000-01-01' }
   }
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -66,7 +66,7 @@ module RouterWrapper
 
   PARAMS_LIMIT = { locations: 10000 }.freeze
   REDIS_COUNT = Redis.new # Fake redis
-  QUOTAS = [{ daily: 100000, monthly: 1000000, yearly: 10000000 }].freeze # Only taken into account if REDIS_COUNT
+  QUOTAS = [{ daily: 10, monthly: 1000000, yearly: 10000000 }].freeze # Only taken into account if REDIS_COUNT
 
   @@c = {
     product_title: 'Router Wrapper API',

--- a/test/api/v01/isoline_test.rb
+++ b/test/api/v01/isoline_test.rb
@@ -81,4 +81,12 @@ class Api::V01::IsolineTest < Minitest::Test
       key =~ /(Content-Type|X-RateLimit-Limit|X-RateLimit-Remaining|X-RateLimit-Reset)/
     }.values
   end
+
+  def test_demo_nil_quotas
+    # assert override 10 by nil (unlimited)
+    11.times do
+      post '/0.1/isoline', { api_key: 'demo_nil_quotas', loc: '43.2804,5.3806', size: 1 }
+      assert last_response.ok?, last_response.body
+    end
+  end
 end

--- a/test/api/v01/matrix_test.rb
+++ b/test/api/v01/matrix_test.rb
@@ -226,4 +226,12 @@ class Api::V01::MatrixTest < Minitest::Test
       key =~ /(Content-Type|X-RateLimit-Limit|X-RateLimit-Remaining|X-RateLimit-Reset)/
     }.values
   end
+
+  def test_demo_nil_quotas
+    # assert override 10 by nil (unlimited)
+    11.times do
+      post '/0.1/matrix', { api_key: 'demo_nil_quotas', src: '43.2804,5.3806,43.2804,5.3806', dst: '43.2804,5.3806', size: 1 }
+      assert last_response.ok?, last_response.body
+    end
+  end
 end

--- a/test/api/v01/route_test.rb
+++ b/test/api/v01/route_test.rb
@@ -180,4 +180,12 @@ class Api::V01::RouteTest < Minitest::Test
       key =~ /(Content-Type|X-RateLimit-Limit|X-RateLimit-Remaining|X-RateLimit-Reset)/
     }.values
   end
+
+  def test_demo_nil_quotas
+    # assert override 10 by nil (unlimited)
+    11.times do
+      post '/0.1/routes', { api_key: 'demo_nil_quotas', locs: '43.2804,5.3806,43.2804,5.3806', size: 1 }
+      assert last_response.ok?, last_response.body
+    end
+  end
 end


### PR DESCRIPTION
This PR allows to override the quotas values with nil so it become unlimited overriding default environnement quotas.

I added  a `before` block in isolines to be like matrix and routes logic.